### PR TITLE
Updated dns.resolver.query() to dns.resolver.resolve() to fix deprecation warnings.

### DIFF
--- a/spoofable.py
+++ b/spoofable.py
@@ -18,7 +18,7 @@ from colorama import Fore, init, Style
 def getSPF(resolver, domain):
 	spfRegex = re.compile("^\"(v=spf1).*\"$")
 	try:
-		answer = resolver.query(domain, 'txt')
+		answer = resolver.resolve(domain, 'txt')
 		for item in answer.response.answer:
 			for line in item.items:
 				if spfRegex.match(line.to_text()):
@@ -29,7 +29,7 @@ def getSPF(resolver, domain):
 def getDMARC(resolver, domain):
 	spfRegex = re.compile("^\"(v=DMARC).*\"$")
 	try:
-		answer = resolver.query("_dmarc." + domain, 'txt')
+		answer = resolver.resolve("_dmarc." + domain, 'txt')
 		for item in answer.response.answer:
 			for line in item.items:
 				if spfRegex.match(line.to_text()):


### PR DESCRIPTION
In dnspython 2.0.0, dns.resolver.query() has been deprecated, dns.resolver.resolve() should be used instead. 

Example of warnings:

`spoofable.py:21: DeprecationWarning: please use dns.resolver.Resolver.resolve() instead`
`spoofable.py:32: DeprecationWarning: please use dns.resolver.Resolver.resolve() instead`

Not a big deal, but a simple fix if backwards compatibility with older dnspython versions is not required.